### PR TITLE
passthru Component and render from preact

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ module.exports = function SomeComponent() {
 }
 ```
 
+or, if you need access to other things from Preact, `Component` and `render`
+are passed thru for your convenience:
+
+```js
+const { h, Component } = require('phy');
+
+class SomeComponent extends Component {
+  render() {
+    return h('#foo', h('span.bar', 'whee!'));
+  }
+}
+module.exports = SomeComponent;
+```
+
 ## Optional Tag Helpers
 
 At the cost of a modestly larger import and slight function call overhead,

--- a/lib/phy.js
+++ b/lib/phy.js
@@ -32,6 +32,8 @@
 
 'use strict';
 
+const preact = require('preact');
+
 // simplified from lodash
 const objectCtorString = Object.toString();
 function isPlainObject(obj) {
@@ -85,4 +87,8 @@ function h(createElement, selector, attrs) {
   return createElement.apply(null, [tag, attrs].concat(kids));
 }
 
-module.exports = h.bind(null, require('preact').createElement);
+module.exports = exports = h.bind(null, preact.createElement);
+
+exports.h = exports;
+exports.Component = preact.Component;
+exports.render = preact.render;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "phy",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/phy.test.js
+++ b/test/phy.test.js
@@ -5,10 +5,18 @@ const assert = require('assertive');
 const h = require('../');
 const render = require('preact-render-to-string');
 
+const { h: h2, Component } = require('../');
+
 function Comp(props) {
   const attrs = Object.assign({}, props);
   delete attrs.children;
   return h('span', attrs, props.children);
+}
+
+class Comp2 extends Component {
+  render() {
+    return h2('span', 'hooray');
+  }
 }
 
 const tests = [
@@ -77,6 +85,7 @@ const tests = [
     h(Comp, { alt: 'meow' }, h('b')),
     '<span alt="meow"><b></b></span>',
   ],
+  ['Component passthru', h2(Comp2), '<span>hooray</span>'],
 ];
 
 describe('phy', () => {


### PR DESCRIPTION
Now instead of:

```js
const { Component } = require('preact');
const h = require('phy');
```

you can say:

```js
const { h, Component } = require('phy');
```

(but the old syntax also works)