### PR TITLE
docs: fix markdown code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ const frag = h(Fragment, [
   h('div', 'two'),
   'three'
 ]);
+```
 
 ## Optional Tag Helpers
 


### PR DESCRIPTION
tribble ` to close the code block were missing